### PR TITLE
Avoid crash in Trainer Tab

### DIFF
--- a/radio/src/gui/480x272/radio_trainer.cpp
+++ b/radio/src/gui/480x272/radio_trainer.cpp
@@ -36,6 +36,8 @@ RadioTrainerPage::RadioTrainerPage():
 void RadioTrainerPage::checkEvents()
 {
   PageTab::checkEvents();
+  
+  if (SLAVE_MODE()) {return;}
   for (int i=0; i<PPM_CHANNELS_TRAINER; i++) {
     int32_t value = 0;
 #if defined (PPM_UNIT_PERCENT_PREC1)


### PR DESCRIPTION
Entering the Trainer Tab crashes, when in Salve Mode. Fix: Check for Slave mode in CheckEvents()