### PR TITLE
[FIX] fix compilation issue for linux users; includes are case sensitive...

### DIFF
--- a/radio/src/gui/480x272/popups.cpp
+++ b/radio/src/gui/480x272/popups.cpp
@@ -20,7 +20,7 @@
 
 #include "opentx.h"
 #include "dialog.h"
-#include "mainWindow.h"
+#include "mainwindow.h"
 
 const char *warningText = NULL;
 const char *warningInfoText;


### PR DESCRIPTION
Hi,

I was wondering why my docker image was not able to compile the firmware anymore... after investigating a bit, I found out that their was a typo in the include directive. I suppose that you build your image on Windows and as its file system is not case sensitive, you did not see the typo.

Here is the fix ;)