### PR TITLE
Switch LCD on, in case USB is plugged

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -2780,6 +2780,7 @@ uint8_t UsbModeSelect( uint32_t index )
     lcd->clearClippingRect();
     if(!index)
     {
+        lcdOn();
         lcdDrawBlackOverlay();
         lcd->drawFilledRect(70, 195, 200, 120, SOLID, HEADER_BGCOLOR);
         const  char *s = STR_USBMODESELECT;


### PR DESCRIPTION
If LCD is off (backlight off) and user plugs usb, he has no chance to see the requested selection. So turn on LCD in case of LCD plugged.