### PR TITLE
Hum when pwr buttons have been pressed long enough for boot

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -2657,6 +2657,7 @@ int main()
   wdt_disable();
 
   boardInit();
+  haptic.play(15, 3, PLAY_NOW);  // short hum to signal that radio is on
 
 #if defined(PCBX7)
   bluetoothInit(BLUETOOTH_DEFAULT_BAUDRATE);   //BT is turn on for a brief period to differentiate X7 and X7S


### PR DESCRIPTION
especially in bright light one can not easily detect, when both power buttons have been pressed long enough to boot the radio up.
Thus hum when inits incl bootloop it over.