### PR TITLE
Change on TX power for Flysky not persisted

### DIFF
--- a/radio/src/gui/480x272/model_setup.cpp
+++ b/radio/src/gui/480x272/model_setup.cpp
@@ -799,6 +799,7 @@ class ModuleWindow : public Window {
             GET_DEFAULT(g_model.moduleData[moduleIndex].romData.rfPower),
             [=](int32_t newValue) -> void {
           g_model.moduleData[moduleIndex].romData.rfPower = newValue;
+          SET_DIRTY();
           onFlySkyModuleSetPower(true);
         });
       }


### PR DESCRIPTION
Change of TX power for internal Flysky module does not get persisted.
SET_DIRTY() is missing.